### PR TITLE
load notmat: check for local audio file

### DIFF
--- a/getNotMatAudioFile.m
+++ b/getNotMatAudioFile.m
@@ -8,13 +8,34 @@ function [audio_fname] = getNotMatAudioFile(notmat_fname)
 % it easier to change fieldname/other behavior later, if need be. 
 % 
 
-load(notmat_fname, 'fname');
+try  % load audio fname from notmat
+    load(notmat_fname, 'fname');
 
-assert( ...
-    exist('fname', 'var'), ...
-    "Provided .not.mat does not have field `fname`! File: " + notmat_fname ...
-);
+    assert( ...
+        exist('fname', 'var'), ...
+        "Provided .not.mat does not have field `fname`! File: " + notmat_fname ...
+    );
+
+    assert( ...
+        exist(fname, 'file'), ...
+        "Audio file does not exist! File: " + fname ...
+    );
+
+catch  % check locally for audio.
+    disp("Trying matching audio file in local dir...")
+
+    fname = replace(notmat_fname, ".not.mat", "");
+
+    assert( ...
+        exist(fname, 'file'), ...
+        "Couldn't find audio locally either! Tried file: " + fname ...
+    );
+
+    % if local audio file does exist, update audio path saved notmat
+    save(notmat_fname, "fname", "-append")
+end
 
 audio_fname = fname;
+
 end
 

--- a/getNotMatAudioFile.m
+++ b/getNotMatAudioFile.m
@@ -10,12 +10,25 @@ function [audio_fname] = getNotMatAudioFile(notmat_fname)
 
 try  % load audio fname from notmat
     load(notmat_fname, 'fname');
+    fname = replace(fname, "\", "/");  % forward slashes compatibile across OS
 
+    % check if var `fname` in `.not.mat` file
     assert( ...
         exist('fname', 'var'), ...
         "Provided .not.mat does not have field `fname`! File: " + notmat_fname ...
     );
 
+    % try updating server address to match OS
+    % won't change path if it's not one of these.
+    if ismac
+        fname = replace(fname, "//macaw.ucsf.edu", "/Volumes");
+    elseif ispc
+        fname = replace(fname, "/Volumes", "//macaw.ucsf.edu");
+    else
+        warning('Platform not supported; may not find files on the server.')
+    end
+
+    % check if file @ fname exists.
     assert( ...
         exist(fname, 'file'), ...
         "Audio file does not exist! File: " + fname ...
@@ -31,8 +44,7 @@ catch  % check locally for audio.
         "Couldn't find audio locally either! Tried file: " + fname ...
     );
 
-    % if local audio file does exist, update audio path saved notmat
-    save(notmat_fname, "fname", "-append")
+    disp("Found local copy of audio to use. File: " + fname);
 end
 
 audio_fname = fname;


### PR DESCRIPTION
In the case that `.not.mat` file `fname` points to nonexistent path, check the `.not.mat`'s local folder for an audio file matching its name (minus ".not.mat"). 

This is applicable when the loaded type is `.not.mat` (from "whole directory", "batch", or "single file" options).